### PR TITLE
Remove dependency of gutil.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 (function(){
   "use strict";
 
-  var gutil = require('gulp-util'),
+  var PluginError = require('plugin-error'),
     through = require('through2'),
     cssjanus = require('cssjanus'),
     _ = require('lodash');
-
 
   module.exports = function (config) {
 
@@ -22,7 +21,7 @@
       }
 
       if (file.isStream()) {
-        this.emit('error', new gutil.PluginError('gulp-cssjanus', 'Streaming not supported'));
+        this.emit('error', new PluginError('gulp-cssjanus', 'Streaming not supported'));
         return cb();
       }
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
   "homepage": "https://github.com/tepez/gulp-cssjanus",
   "dependencies": {
     "cssjanus": "^1.1.2",
-    "gulp-util": "^3.0.5",
     "lodash": "^3.9.3",
-    "through2": "^0.6.5"
+    "plugin-error": "^1.0.1",
+    "through2": "^0.6.5",
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 (function() {
 
   'use strict';
-  var gutil = require('gulp-util'),
+  var Vinyl = require('vinyl'),
     cssjanus = require('cssjanus'),
     gulpCssjanus = require('./index'),
     expect = require('chai').expect,
@@ -28,7 +28,7 @@
         done();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: 'styles.css',
         contents: new Buffer('.selector { float: left; /* comment */ }')
       }));
@@ -45,7 +45,7 @@
         done();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: 'styles.css',
         contents: new Buffer('.selector { float: left; /* comment */ }')
       }));
@@ -66,7 +66,7 @@
         done();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: 'styles.css',
         contents: new Buffer('.selector { float: left; /* comment */ }')
       }));
@@ -96,7 +96,7 @@
         done();
       });
 
-      stream.write(new gutil.File({
+      stream.write(new Vinyl({
         path: 'styles.css',
         contents: new Buffer('.selector { float: left; /* comment */ }')
       }));


### PR DESCRIPTION
gulp-utils has been deprecated, and this will not install with Node 10. This
commit removes the dependencies as per https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5